### PR TITLE
Add macOS-use setup script and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # ai-agent
+
+This repository demonstrates a simple multi-agent system.
+
+## 🛠 Cài đặt macOS-use và khởi động hệ thống
+
+```bash
+chmod +x scripts/setup_full.sh
+./scripts/setup_full.sh
+```

--- a/agent-system/tools/macos_use_wrapper.py
+++ b/agent-system/tools/macos_use_wrapper.py
@@ -12,3 +12,7 @@ def run_applescript(script: str) -> None:
     """Run an AppleScript via macos-use."""
     subprocess.run(["macos-use", "osascript", script], check=False)
 
+
+if __name__ == "__main__":
+    print(open_app("Safari"))
+

--- a/scripts/setup_full.sh
+++ b/scripts/setup_full.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "🔧 Cloning macOS-use if not exists..."
+if [ ! -d "macOS-use" ]; then
+  git clone https://github.com/browser-use/macOS-use.git
+fi
+
+echo "📦 Installing macOS-use..."
+cd macOS-use
+pip install -e .
+cd ..
+
+echo "📦 Installing AI-agent dependencies..."
+pip install -r agent-system/requirements.txt
+
+echo "✅ Setup completed successfully."
+


### PR DESCRIPTION
## Summary
- add macOS-use setup script under `scripts/setup_full.sh`
- document how to run the setup script in README
- add a simple test block to `macos_use_wrapper.py`

## Testing
- `python -m py_compile agent-system/tools/macos_use_wrapper.py`
- `bash -n scripts/setup_full.sh`
- `bash scripts/setup_full.sh` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68523fed0d44832fb41384039501b7cd